### PR TITLE
Set config only on the initiall addon instalation. Fix #1

### DIFF
--- a/FeedlyBackground/background.js
+++ b/FeedlyBackground/background.js
@@ -2,7 +2,7 @@ var receiveRequest = function (message, sender, response) {
   chrome.tabs.create({ url: message.url, active: false });
 };
 
-var onInstall = function () {
+var onInstall = function (details) {
   if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
     chrome.storage.sync.set({ hotkey: ';' }, function () {
       console.log("Set default hotkey to ;");

--- a/FeedlyBackground/background.js
+++ b/FeedlyBackground/background.js
@@ -3,9 +3,11 @@ var receiveRequest = function (message, sender, response) {
 };
 
 var onInstall = function () {
-  chrome.storage.sync.set({ hotkey: ';' }, function () {
-    console.log("Set default hotkey to ;");
-  });
+  if (details.reason === chrome.runtime.OnInstalledReason.INSTALL) {
+    chrome.storage.sync.set({ hotkey: ';' }, function () {
+      console.log("Set default hotkey to ;");
+    });
+  }
 }
 
 


### PR DESCRIPTION
Based on https://developer.chrome.com/docs/extensions/reference/runtime/#example-uninstall-url and https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnInstalledReason